### PR TITLE
SourceVersion に関する警告を抑制する。

### DIFF
--- a/src/main/java/in/tombo/ponto/PontoProcessor.java
+++ b/src/main/java/in/tombo/ponto/PontoProcessor.java
@@ -14,6 +14,8 @@ import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic;
@@ -21,6 +23,7 @@ import javax.tools.Diagnostic.Kind;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardLocation;
 
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @SupportedAnnotationTypes("in.tombo.ponto.ConstantResource")
 public class PontoProcessor extends AbstractProcessor {
 


### PR DESCRIPTION
java 1.7 以上でbuild すると　下記の警告が発生する。

> [WARNING] No SupportedSourceVersion annotation found on in.tombo.ponto.PontoProcessor, returning RELEASE_6.
> [WARNING] 注釈プロセッサ'in.tombo.ponto.PontoProcessor'から-source '1.8'より小さいソース・バージョン'RELEASE_6'がサポートされています

in.tombo.ponto.PontoProcessor の継承元クラスを読むと下記の記述があり、
@SupportedSourceVersion 追加しないとデフォルトではRELEASE_6となる。

> /**
>      \* If the processor class is annotated with {@link
>      \* SupportedSourceVersion}, return the source version in the
>      \* annotation.  If the class is not so annotated, {@link
>      \* SourceVersion#RELEASE_6} is returned.
>      *
>      \* @return the latest source version supported by this processor
>      */
>     public SourceVersion getSupportedSourceVersion() {

@SupportedSourceVersion(SourceVersion.RELEASE_8) を追加し警告が発生しないように修正した。
